### PR TITLE
Add the -select category, so that only selected nodes are loaded and started

### DIFF
--- a/src-tests/test/deployment/select/Boot.java
+++ b/src-tests/test/deployment/select/Boot.java
@@ -1,0 +1,21 @@
+package deployment.select;
+
+import net.xqhs.flash.FlashBoot;
+
+/**
+ * Deployment with select
+ */
+public class Boot {
+
+    /**
+     * Main method. Performs test
+     *
+     * @param args
+     *              -not used.
+     */
+    public static void main(String[] args) {
+        String test_args = "-select node1 node3 -node node1 -node node2 -node node3 -node node4";
+
+        FlashBoot.main(test_args.split(" "));
+    }
+}

--- a/src-tests/test/deployment/select/Boot.java
+++ b/src-tests/test/deployment/select/Boot.java
@@ -14,7 +14,7 @@ public class Boot {
      *              -not used.
      */
     public static void main(String[] args) {
-        String test_args = "-no-start true -select node1 node3 -node node1 -node node2 -node node3 -node node4";
+        String test_args = "-nostart true -select node1 node3 -node node1 -node node2 -node node3 -node node4";
 
         FlashBoot.main(test_args.split(" "));
     }

--- a/src-tests/test/deployment/select/Boot.java
+++ b/src-tests/test/deployment/select/Boot.java
@@ -1,4 +1,4 @@
-package deployment.select;
+package test.deployment.select;
 
 import net.xqhs.flash.FlashBoot;
 
@@ -14,7 +14,7 @@ public class Boot {
      *              -not used.
      */
     public static void main(String[] args) {
-        String test_args = "-select node1 node3 -node node1 -node node2 -node node3 -node node4";
+        String test_args = "-no-start true -select node1 node3 -node node1 -node node2 -node node3 -node node4";
 
         FlashBoot.main(test_args.split(" "));
     }

--- a/src-tests/test/deployment/select/package-info.java
+++ b/src-tests/test/deployment/select/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Tests for deployment configuration with select.
+ *
+ *
+ */
+
+package deployment.select;

--- a/src-tests/test/deployment/select/package-info.java
+++ b/src-tests/test/deployment/select/package-info.java
@@ -4,4 +4,4 @@
  *
  */
 
-package deployment.select;
+package test.deployment.select;

--- a/src/net/xqhs/flash/FlashBoot.java
+++ b/src/net/xqhs/flash/FlashBoot.java
@@ -40,13 +40,9 @@ public class FlashBoot
 		// stream = new ByteArrayOutputStream();
 		// GlobalLogWrapper.setLogStream(stream);
         boolean shouldStart = true;
-        //if (args.length > 0 && "-no-start".equals(args[0])) {
-            // shouldStart = false;
-            // args = Arrays.copyOfRange(args, 1, args.length);
-        //}
 
 		List<Node> nodes = Deployment.get().loadDeployment(Arrays.asList(args));
-        shouldStart = !Deployment.get().isNoStart();
+        shouldStart = Deployment.get().doStart();
 
 		// try {
 		// Thread.sleep(20000);

--- a/src/net/xqhs/flash/FlashBoot.java
+++ b/src/net/xqhs/flash/FlashBoot.java
@@ -40,13 +40,14 @@ public class FlashBoot
 		// stream = new ByteArrayOutputStream();
 		// GlobalLogWrapper.setLogStream(stream);
         boolean shouldStart = true;
-        if (args.length > 0 && "no-start".equals(args[0])) {
-            shouldStart = false;
-
-            args = Arrays.copyOfRange(args, 1, args.length);
-        }
+        //if (args.length > 0 && "-no-start".equals(args[0])) {
+            // shouldStart = false;
+            // args = Arrays.copyOfRange(args, 1, args.length);
+        //}
 
 		List<Node> nodes = Deployment.get().loadDeployment(Arrays.asList(args));
+        shouldStart = !Deployment.get().isNoStart();
+
 		// try {
 		// Thread.sleep(20000);
 		// } catch(InterruptedException e) {

--- a/src/net/xqhs/flash/core/CategoryName.java
+++ b/src/net/xqhs/flash/core/CategoryName.java
@@ -102,7 +102,7 @@ public enum CategoryName {
     /**
      * A special category name which indicates that no node should be started.
      */
-    NO_START(new CatPar().isUnique().isValue().hasParent(DEPLOYMENT))
+    NOSTART(new CatPar().isUnique().isValue().hasParent(DEPLOYMENT))
     ;
 
 	/**

--- a/src/net/xqhs/flash/core/CategoryName.java
+++ b/src/net/xqhs/flash/core/CategoryName.java
@@ -98,6 +98,11 @@ public enum CategoryName {
      * Nodes to be loaded and started (only the selected nodes will be loaded and started).
      */
     SELECT(new CatPar().isValue().hasParent(DEPLOYMENT)),
+
+    /**
+     * A special category name which indicates that no node should be started.
+     */
+    NO_START(new CatPar().isUnique().isValue().hasParent(DEPLOYMENT))
     ;
 
 	/**

--- a/src/net/xqhs/flash/core/CategoryName.java
+++ b/src/net/xqhs/flash/core/CategoryName.java
@@ -93,9 +93,13 @@ public enum CategoryName {
 	 */
 	LOADER(new CatPar().isIdentifiable().isNotEntity().hasPartName("for", "kind", Is.OPTIONAL).hasParent(NODE)
 			.isPortableFrom(DEPLOYMENT)),
-	
-	;
-	
+
+    /**
+     * Nodes to be loaded and started (only the selected nodes will be loaded and started).
+     */
+    SELECT(new CatPar().isValue().hasParent(DEPLOYMENT)),
+    ;
+
 	/**
 	 * Values in this enumeration indicate whether a constraint is optional or mandatory.
 	 */

--- a/src/net/xqhs/flash/core/DeploymentConfiguration.java
+++ b/src/net/xqhs/flash/core/DeploymentConfiguration.java
@@ -929,7 +929,7 @@ public class DeploymentConfiguration extends MultiTreeMap {
 	 * @return the category name.
 	 */
 	protected static String getCategoryName(String arg) {
-		return isCategoryDefinition(arg) ? arg.substring(1) : null;
+		return isCategoryDefinition(arg) ? arg.substring(1).replace("-", "_") : null;
 	}
 	
 	/**

--- a/src/net/xqhs/flash/core/DeploymentConfiguration.java
+++ b/src/net/xqhs/flash/core/DeploymentConfiguration.java
@@ -929,7 +929,7 @@ public class DeploymentConfiguration extends MultiTreeMap {
 	 * @return the category name.
 	 */
 	protected static String getCategoryName(String arg) {
-		return isCategoryDefinition(arg) ? arg.substring(1).replace("-", "_") : null;
+		return isCategoryDefinition(arg) ? arg.substring(1) : null;
 	}
 	
 	/**

--- a/src/net/xqhs/flash/core/deployment/Deployment.java
+++ b/src/net/xqhs/flash/core/deployment/Deployment.java
@@ -64,30 +64,6 @@ public class Deployment extends Unit {
 		return new LoadPack(PlatformUtils.getClassFactory(), deploymentID, log != null ? log : getLogger());
 	}
 
-
-    /**
-     * Extracts the node names that are given as arguments to the -select category.
-     * @param args - the arguments sent to the CLI
-     * @return a list of Strings representing the node names that are selected
-     */
-    public List<String> getSelectedNodes(List<String> args) {
-        List<String> selectedNodes = new LinkedList<>();
-
-        for (int i = 0; i < args.size(); i++) {
-            if (args.get(i).equals("-select")) {
-                i++;
-                while (i < args.size() && !args.get(i).startsWith("-")) {
-                    selectedNodes.add(args.get(i));
-                    i++;
-                }
-                i--;
-            }
-        }
-
-        return selectedNodes;
-    }
-
-
 	/**
 	 * Loads a deployment starting from command line arguments.
 	 * <p>
@@ -125,7 +101,11 @@ public class Deployment extends Unit {
 		NodeLoader nodeLoader = new NodeLoader();
 		nodeLoader.configure(null, getBasicLoadPack(null));
 
-        List<String> selectedNodes = getSelectedNodes(args);
+        MultiTreeMap deploymentTree = DeploymentConfiguration
+                .filterCategoryInContext(allEntities, CategoryName.DEPLOYMENT.s(), null).get(0);
+
+        // get the list of the selected nodes from the SELECT category
+        List<String> selectedNodes = deploymentTree.getValues(CategoryName.SELECT.s());
 
         // filter the nodesTree by the selected nodes so that only those nodes will be loaded and started
         if (!selectedNodes.isEmpty()) {

--- a/src/net/xqhs/flash/core/deployment/Deployment.java
+++ b/src/net/xqhs/flash/core/deployment/Deployment.java
@@ -47,9 +47,9 @@ public class Deployment extends Unit {
 	String deploymentID = null;
 
     /**
-     * Field set by the no-start category name. If true, then no node should start.
+     * Field set by the nostart category name. If false, then no node should start.
      */
-    private boolean noStart = false;
+    private boolean start = true;
 	
 	/**
 	 * @return the singleton instance of the deployment.
@@ -59,10 +59,10 @@ public class Deployment extends Unit {
 	}
 
     /**
-     * @return the value of the noStart field
+     * @return the value of the start field.
      */
-    public boolean isNoStart() {
-        return noStart;
+    public boolean doStart() {
+        return start;
     }
 	
 	/**
@@ -116,8 +116,8 @@ public class Deployment extends Unit {
         MultiTreeMap deploymentTree = DeploymentConfiguration
                 .filterCategoryInContext(allEntities, CategoryName.DEPLOYMENT.s(), null).get(0);
 
-        // check if no_start category name is set true
-        noStart = Boolean.parseBoolean(deploymentTree.getSingleValue(CategoryName.NO_START.s()));
+        // check if no_start category name is set
+        start = !deploymentTree.isSet(CategoryName.NOSTART.s());
 
         // get the list of the selected nodes from the SELECT category
         List<String> selectedNodes = deploymentTree.getValues(CategoryName.SELECT.s());

--- a/src/net/xqhs/flash/core/deployment/Deployment.java
+++ b/src/net/xqhs/flash/core/deployment/Deployment.java
@@ -63,7 +63,31 @@ public class Deployment extends Unit {
 	public LoadPack getBasicLoadPack(Logger log) {
 		return new LoadPack(PlatformUtils.getClassFactory(), deploymentID, log != null ? log : getLogger());
 	}
-	
+
+
+    /**
+     * Extracts the node names that are given as arguments to the -select category.
+     * @param args - the arguments sent to the CLI
+     * @return a list of Strings representing the node names that are selected
+     */
+    public List<String> getSelectedNodes(List<String> args) {
+        List<String> selectedNodes = new LinkedList<>();
+
+        for (int i = 0; i < args.size(); i++) {
+            if (args.get(i).equals("-select")) {
+                i++;
+                while (i < args.size() && !args.get(i).startsWith("-")) {
+                    selectedNodes.add(args.get(i));
+                    i++;
+                }
+                i--;
+            }
+        }
+
+        return selectedNodes;
+    }
+
+
 	/**
 	 * Loads a deployment starting from command line arguments.
 	 * <p>
@@ -100,6 +124,26 @@ public class Deployment extends Unit {
 				.get(0).getAValue(DeploymentConfiguration.LOCAL_ID_ATTRIBUTE);
 		NodeLoader nodeLoader = new NodeLoader();
 		nodeLoader.configure(null, getBasicLoadPack(null));
+
+        List<String> selectedNodes = getSelectedNodes(args);
+
+        // filter the nodesTree by the selected nodes so that only those nodes will be loaded and started
+        if (!selectedNodes.isEmpty()) {
+            List<MultiTreeMap> filteredNodesTrees = new LinkedList<>();
+            for (MultiTreeMap node : nodesTrees) {
+                String name = node.getFirstValue(DeploymentConfiguration.NAME_ATTRIBUTE_NAME);
+                if (selectedNodes.contains(name)) {
+                    filteredNodesTrees.add(node);
+                }
+            }
+
+            nodesTrees = filteredNodesTrees;
+            lf("Node selection active. Selected nodes: []", selectedNodes);
+        }
+        if (!selectedNodes.isEmpty() && nodesTrees.isEmpty()) {
+            lw("No matching nodes found for selection: []", selectedNodes);
+        }
+
 		for(MultiTreeMap nodeConfig : nodesTrees) {
 			lf("Loading node ", EntityIndex.mockPrint(CategoryName.NODE.s(),
 					nodeConfig.getFirstValue(DeploymentConfiguration.NAME_ATTRIBUTE_NAME)));

--- a/src/net/xqhs/flash/core/deployment/Deployment.java
+++ b/src/net/xqhs/flash/core/deployment/Deployment.java
@@ -45,6 +45,11 @@ public class Deployment extends Unit {
 	 * The ID of the deployment.
 	 */
 	String deploymentID = null;
+
+    /**
+     * Field set by the no-start category name. If true, then no node should start.
+     */
+    private boolean noStart = false;
 	
 	/**
 	 * @return the singleton instance of the deployment.
@@ -52,6 +57,13 @@ public class Deployment extends Unit {
 	public static Deployment get() {
 		return deployment;
 	}
+
+    /**
+     * @return the value of the noStart field
+     */
+    public boolean isNoStart() {
+        return noStart;
+    }
 	
 	/**
 	 * Creates a basic {@link LoadPack} using the current deployment ID and a given {@link Logger}.
@@ -103,6 +115,9 @@ public class Deployment extends Unit {
 
         MultiTreeMap deploymentTree = DeploymentConfiguration
                 .filterCategoryInContext(allEntities, CategoryName.DEPLOYMENT.s(), null).get(0);
+
+        // check if no_start category name is set true
+        noStart = Boolean.parseBoolean(deploymentTree.getSingleValue(CategoryName.NO_START.s()));
 
         // get the list of the selected nodes from the SELECT category
         List<String> selectedNodes = deploymentTree.getValues(CategoryName.SELECT.s());


### PR DESCRIPTION

This commit solves the first two TODO items for the issue #68. The -select category receives node names as arguments. A list of Strings representing the name of the selected nodes is made. Only the selected nodes are filtered from the deployment configuration and passed to the loading process then started.