### PR TITLE
Remove empty categories after auto-created entity cleanup and add deployment convergence tests 

### DIFF
--- a/src-tests/test/deployment/convergence/Boot1a.java
+++ b/src-tests/test/deployment/convergence/Boot1a.java
@@ -4,7 +4,10 @@ import net.xqhs.flash.FlashBoot;
 
 /**
  * Test 1a: node and pylon in XML, agents added via CLI - automatic porting to pylon.
- */
+ * <p>
+ * Expected behavior: agents are automatically ported to the pylon defined in the XML deployment file.
+ * AgentA sends 5 ping messages to AgentB, which replies to each. Both agents stop after the ping limit is reached.
+*/
 
 public class Boot1a
 {    

--- a/src-tests/test/deployment/convergence/Boot1a.java
+++ b/src-tests/test/deployment/convergence/Boot1a.java
@@ -1,0 +1,22 @@
+package test.deployment.convergence;
+
+import net.xqhs.flash.FlashBoot;
+
+/**
+ * Test 1a: node and pylon in XML, agents added via CLI - automatic porting to pylon.
+ */
+
+public class Boot1a
+{    
+    public static void main(String[] args)
+    {
+        String test_args = "src-tests/test/deployment/convergence/deployment1.xml";
+        
+        test_args += " -package testing";
+        test_args += " -agent PingPong:AgentA classpath:AgentPingPong sendTo:AgentB";
+		test_args += " -agent PingPong:AgentB classpath:AgentPingPong";
+        
+        FlashBoot.main(test_args.split(" "));
+    }
+
+}

--- a/src-tests/test/deployment/convergence/Boot1b.java
+++ b/src-tests/test/deployment/convergence/Boot1b.java
@@ -4,7 +4,11 @@ import net.xqhs.flash.FlashBoot;
 
 /**
  * Test 1b: node and pylon in XML, agents added via CLI with explicit in-context-of.
- */
+ * <p>
+ * Expected behavior: agents are placed in the pylon specified by the in-context-of parameter.
+ * AgentA sends 5 ping messages to AgentB, which replies to each. Both agents stop after 
+ * the ping limit is reached.
+*/
 
 public class Boot1b
 {

--- a/src-tests/test/deployment/convergence/Boot1b.java
+++ b/src-tests/test/deployment/convergence/Boot1b.java
@@ -1,0 +1,21 @@
+package test.deployment.convergence;
+
+import net.xqhs.flash.FlashBoot;
+
+/**
+ * Test 1b: node and pylon in XML, agents added via CLI with explicit in-context-of.
+ */
+
+public class Boot1b
+{
+    public static void main(String[] args)
+	{
+		String test_args = "src-tests/test/deployment/convergence/deployment1.xml";
+		
+        test_args += " -package testing";
+		test_args += " -agent PingPong:AgentA classpath:AgentPingPong sendTo:AgentB in-context-of:def";
+		test_args += " -agent PingPong:AgentB classpath:AgentPingPong in-context-of:def";
+		
+		FlashBoot.main(test_args.split(" "));
+	}
+}

--- a/src-tests/test/deployment/convergence/Boot2.java
+++ b/src-tests/test/deployment/convergence/Boot2.java
@@ -4,7 +4,12 @@ import net.xqhs.flash.FlashBoot;
 
 /**
  * Test 2: node in CLI, pylon and agents in XML with in-context-of.
- */
+ * <p>
+ * Expected behavior: the pylon defined in XML with in-context-of pointing 
+ * to the CLI-defined node is correctly placed under that node. AgentA 
+ * sends 5 ping messages to AgentB, which replies to each. Both agents 
+ * stop after the ping limit is reached.
+*/
 
 public class Boot2
 {

--- a/src-tests/test/deployment/convergence/Boot2.java
+++ b/src-tests/test/deployment/convergence/Boot2.java
@@ -1,0 +1,20 @@
+package test.deployment.convergence;
+
+import net.xqhs.flash.FlashBoot;
+
+/**
+ * Test 2: node in CLI, pylon and agents in XML with in-context-of.
+ */
+
+public class Boot2
+{
+    public static void main(String[] args)
+	{
+		String test_args = "src-tests/test/deployment/convergence/deployment2.xml";
+		
+        test_args += " -package testing";
+		test_args += " -node main";
+		
+		FlashBoot.main(test_args.split(" "));
+	}
+}

--- a/src-tests/test/deployment/convergence/Boot3.java
+++ b/src-tests/test/deployment/convergence/Boot3.java
@@ -1,0 +1,21 @@
+package test.deployment.convergence;
+
+import net.xqhs.flash.FlashBoot;
+
+/**
+ * Test 3: full deployment in XML, additional parameters added through CLI for same agents.
+ */
+
+public class Boot3
+{
+    public static void main(String[] args)
+	{
+		String test_args = "src-tests/test/deployment/convergence/deployment3.xml";
+		
+        test_args += " -package testing";
+        test_args += " -agent AgentA ping-number:3";
+		test_args += " -agent AgentC ping-number:3";
+		
+		FlashBoot.main(test_args.split(" "));
+	}
+}

--- a/src-tests/test/deployment/convergence/Boot3.java
+++ b/src-tests/test/deployment/convergence/Boot3.java
@@ -4,7 +4,14 @@ import net.xqhs.flash.FlashBoot;
 
 /**
  * Test 3: full deployment in XML, additional parameters added through CLI for same agents.
- */
+ * <p>
+ * Expected behavior: agents specified in CLI with the same name as agents in XML should be treated
+ * as the same agents, with the CLI parameters added to their configuration.
+ * <p>
+ * Current limitation: the framework creates duplicate agent instances instead of merging the
+ * configurations. The ping-number:3 parameter from CLI is not applied to the XML agents, which
+ * still send the default 5 ping messages.
+*/
 
 public class Boot3
 {

--- a/src-tests/test/deployment/convergence/deployment1.xml
+++ b/src-tests/test/deployment/convergence/deployment1.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<deployment xmlns="http://flash.xqhs.net/deployment-schema"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://flash.xqhs.net/deployment-schema ../../src-schema/deployment-schema.xsd">
+
+	<node name="main">
+		<pylon kind="local" name="def"/>
+	</node>
+
+</deployment>

--- a/src-tests/test/deployment/convergence/deployment2.xml
+++ b/src-tests/test/deployment/convergence/deployment2.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<deployment xmlns="http://flash.xqhs.net/deployment-schema"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://flash.xqhs.net/deployment-schema ../../src-schema/deployment-schema.xsd">
+
+	<pylon kind="local">
+		<parameter name="in-context-of" value="main"/>
+		<agent name="PingPong:AgentA" classpath="AgentPingPong">
+			<parameter name="sendTo" value="AgentB"/>
+		</agent>
+		<agent name="PingPong:AgentB" classpath="AgentPingPong"/>
+	</pylon>
+
+</deployment>

--- a/src-tests/test/deployment/convergence/deployment3.xml
+++ b/src-tests/test/deployment/convergence/deployment3.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<deployment xmlns="http://flash.xqhs.net/deployment-schema"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://flash.xqhs.net/deployment-schema ../../src-schema/deployment-schema.xsd">
+
+	<node name="node1">
+		<pylon kind="local">
+			<agent name="AgentA" classpath="AgentPingPong">
+				<parameter name="sendTo" value="AgentB"/>
+			</agent>
+			<agent name="AgentB" classpath="AgentPingPong"/>
+		</pylon>
+	</node>
+    
+	<node name="node2">
+		<pylon kind="local">
+			<agent name="AgentC" classpath="AgentPingPong">
+				<parameter name="sendTo" value="AgentD"/>
+			</agent>
+			<agent name="AgentD" classpath="AgentPingPong"/>
+		</pylon>
+	</node>
+
+</deployment>

--- a/src-tests/test/deployment/convergence/package-info.java
+++ b/src-tests/test/deployment/convergence/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Tests for deployment convergence between XML and CLI configuration.
+ */
+package test.deployment.convergence;

--- a/src/net/xqhs/flash/core/DeploymentConfiguration.java
+++ b/src/net/xqhs/flash/core/DeploymentConfiguration.java
@@ -367,6 +367,10 @@ public class DeploymentConfiguration extends MultiTreeMap {
 								subCat.remove(name, tree);
 								log.lf("removed one tree for [] (id: []) from []/[[]", name, id, parentID, subCategory);
 							}
+							if(subCat.getHierarchicalNames().isEmpty()) {
+								localIDs.getSingleTree(parentID).removeKey(subCategory);
+								log.lf("removed empty category [] from []", subCategory, parentID);
+							}
 				}
 			localIDs.removeKey(id);
 		}

--- a/src/net/xqhs/flash/core/DeploymentConfiguration.java
+++ b/src/net/xqhs/flash/core/DeploymentConfiguration.java
@@ -367,6 +367,8 @@ public class DeploymentConfiguration extends MultiTreeMap {
 								subCat.remove(name, tree);
 								log.lf("removed one tree for [] (id: []) from []/[[]", name, id, parentID, subCategory);
 							}
+							// after removing the entity, check if the category key is now empty and remove it as well,
+        					// to avoid leaving empty category keys in the configuration tree.
 							if(subCat.getHierarchicalNames().isEmpty()) {
 								localIDs.getSingleTree(parentID).removeKey(subCategory);
 								log.lf("removed empty category [] from []", subCategory, parentID);


### PR DESCRIPTION
This PR removes empty category keys left behind after auto-created entity cleanup.
After auto-created entities are removed, some category keys, such as `pylon`, can remain in the configuration even though they no longer contain any entries. The added check removes these category keys when they become empty.
Also adds deployment convergence tests in src-tests/test/deployment/convergence, 
testing combinations of XML and CLI configuration:
- Test 1a: node and pylon in XML, agents added via CLI (automatic porting)
- Test 1b: node and pylon in XML, agents added via CLI with explicit in-context-of
- Test 2: node in CLI, pylon and agents in XML with in-context-of
- Test 3: full deployment in XML, additional parameters through CLI