### PR TITLE
Add porting tests for issue #31

### DIFF
--- a/src-tests/test/deployment/porting/BootPorting.java
+++ b/src-tests/test/deployment/porting/BootPorting.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (C) 2021 Andrei Olaru.
+ * 
+ * This file is part of Flash-MAS. The CONTRIBUTORS.md file lists people who have been previously involved with this project.
+ * 
+ * Flash-MAS is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or any later version.
+ * 
+ * Flash-MAS is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with Flash-MAS.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+package test.deployment.porting;
+
+import net.xqhs.flash.FlashBoot;
+
+public class BootPorting {
+    static String THIS_DIRECTORY = "src-tests/test/deployment/porting/";
+    
+    public static void main(String[] args_) {
+        //String args = "no-start " + THIS_DIRECTORY + "scenario1.xml";
+        //String args = "no-start " + THIS_DIRECTORY + "scenario2.xml";
+        //String args = "no-start " + THIS_DIRECTORY + "scenario3.xml";
+        String args = "no-start " + THIS_DIRECTORY + "scenario4.xml";
+        FlashBoot.main(args.split(" "));
+    }
+}

--- a/src-tests/test/deployment/porting/BootPortingShard.java
+++ b/src-tests/test/deployment/porting/BootPortingShard.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (C) 2021 Andrei Olaru.
+ * 
+ * This file is part of Flash-MAS. The CONTRIBUTORS.md file lists people who have been previously involved with this project.
+ * 
+ * Flash-MAS is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or any later version.
+ * 
+ * Flash-MAS is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with Flash-MAS.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+package test.deployment.porting;
+
+import net.xqhs.flash.FlashBoot;
+
+public class BootPortingShard {
+    
+    public static void main(String[] args_) {
+        String args = "no-start"
+            + " -package testing"
+            + " -shard messaging"
+            + " -agent AgentA classpath:AgentPingPong"
+            + " -agent AgentB classpath:AgentPingPong";
+        FlashBoot.main(args.split(" "));
+    }
+}

--- a/src-tests/test/deployment/porting/package-info.java
+++ b/src-tests/test/deployment/porting/package-info.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (C) 2021 Andrei Olaru.
+ * 
+ * This file is part of Flash-MAS. The CONTRIBUTORS.md file lists people who have been previously involved with this project.
+ * 
+ * Flash-MAS is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or any later version.
+ * 
+ * Flash-MAS is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with Flash-MAS.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+/**
+ * Tests for porting behavior in deployment configuration (Issue #31).
+ * <p>
+ * Tests what happens when non-predefined categories (agentarray) or predefined 
+ * categories (shard) are declared between predefined hierarchy levels.
+ * <p>
+ * Scenarios tested:
+ * <ul>
+ * <li>scenario1.xml — agentarray with agent at deployment level</li>
+ * <li>scenario2.xml — agentarray with agent inside a node</li>
+ * <li>scenario3.xml — shard explicitly under each agent (correct baseline)</li>
+ * <li>scenario4.xml — two pylons, two agents without in-context-of</li>
+ * </ul>
+ * <p>
+ * <b>Verifies:</b> correct porting and lifting behavior in
+ * {@link net.xqhs.flash.core.DeploymentConfiguration#postProcess}
+ */
+package test.deployment.porting;

--- a/src-tests/test/deployment/porting/scenario1.xml
+++ b/src-tests/test/deployment/porting/scenario1.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<deployment xmlns="http://flash.xqhs.net/deployment-schema"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://flash.xqhs.net/deployment-schema 
+    ../../../src-schema/deployment-schema.xsd">
+
+    <entity type="agentarray">
+        <entity type="agent" kind="composite">
+            <in-context-of>websockets</in-context-of>
+        </entity>
+    </entity>
+
+    <package>testing</package>
+
+    <loader for="agent" classpath="net.xqhs.flash.deployment.CompositeAgentLoader" />
+
+    <pylon kind="websockets" />
+
+    <pylon kind="custom">
+        <parameter name="classpath" value="custom" />
+    </pylon>
+
+</deployment>

--- a/src-tests/test/deployment/porting/scenario2.xml
+++ b/src-tests/test/deployment/porting/scenario2.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<deployment xmlns="http://flash.xqhs.net/deployment-schema"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://flash.xqhs.net/deployment-schema 
+    ../../../src-schema/deployment-schema.xsd">
+
+    <package>testing</package>
+    <loader for="agent" classpath="net.xqhs.flash.deployment.CompositeAgentLoader" />
+    <pylon kind="local" />
+
+    <node name="node1">
+        <entity type="agentarray">
+            <entity type="agent" kind="composite" />
+        </entity>
+    </node>
+
+</deployment>

--- a/src-tests/test/deployment/porting/scenario3.xml
+++ b/src-tests/test/deployment/porting/scenario3.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<deployment xmlns="http://flash.xqhs.net/deployment-schema"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://flash.xqhs.net/deployment-schema 
+    ../../../src-schema/deployment-schema.xsd">
+
+    <package>testing</package>
+
+    <pylon kind="local">
+        <agent name="AgentA" classpath="AgentPingPong">
+            <shard name="messaging" />
+        </agent>
+        <agent name="AgentB" classpath="AgentPingPong">
+            <shard name="messaging" />
+        </agent>
+    </pylon>
+
+</deployment>

--- a/src-tests/test/deployment/porting/scenario4.xml
+++ b/src-tests/test/deployment/porting/scenario4.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<deployment xmlns="http://flash.xqhs.net/deployment-schema"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://flash.xqhs.net/deployment-schema 
+    ../../../src-schema/deployment-schema.xsd">
+
+    <package>testing</package>
+
+    <pylon kind="local" name="PA" />
+    <pylon kind="local" name="PB" />
+
+    <agent name="AgentA" classpath="AgentPingPong" />
+    <agent name="AgentB" classpath="AgentPingPong" />
+
+</deployment>

--- a/src/net/xqhs/flash/core/DeploymentConfiguration.java
+++ b/src/net/xqhs/flash/core/DeploymentConfiguration.java
@@ -275,7 +275,7 @@ public class DeploymentConfiguration extends MultiTreeMap {
 			ContentHolder<XMLTree> loadedXML) throws ConfigLockedException {
 		locked();
 		UnitComponent log = new UnitComponent("settings load").setLoggerType(PlatformUtils.platformLogType())
-				.setLogLevel(Level.INFO);
+				.setLogLevel(Level.ALL);
 		MultiTreeMap deploymentCat = this.getSingleTree(CategoryName.DEPLOYMENT.s());
 		MultiTreeMap deployment = deploymentCat.getSingleTree(null);
 		
@@ -580,6 +580,16 @@ public class DeploymentConfiguration extends MultiTreeMap {
 						child, caller);
 				return false;
 			}
+			/* 
+			if(CategoryName.byName(child) != null && CategoryName.byName(child).portableFrom() == null
+					&& caller.equals(CategoryName.byName(child).getParent())) {
+				// child is a declared category, is not portable, AND belongs here -> return false
+				log.lf("Found non-portable category [] inside caller category; caller category [] will be lifted instead of ported. ",
+						child, caller);
+				return false;
+			}
+			*/
+			
 			if(tree.isHierarchical(child))
 				if(tree.isSingleton(child)) {
 					if(!allPortable(tree.getATree(child), caller, log))


### PR DESCRIPTION
Adds test package test.deployment.porting with scenarios for porting behavior 
in deployment configuration.

Scenarios:
- scenario1.xml — agentarray with agent at deployment level
- scenario2.xml — agentarray with agent inside a node  
- scenario3.xml — shard explicitly under each agent (correct baseline)
- scenario4.xml — two pylons, two agents without in-context-of

Also includes a commented proposed fix in DeploymentConfiguration.java 
for review (allPortable() condition).

Related to #31.